### PR TITLE
Apply patch from Mats Kindahl for fixing pg upgrade

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -251,8 +251,21 @@ ts_extension_invalidate(Oid relid)
 bool
 ts_extension_is_loaded(void)
 {
-	/* when restoring deactivate extension */
-	if (ts_guc_restoring)
+	elog(DEBUG1,
+		 "%s: timescaledb.restoring=%s, IsBinaryUpgrade=%s",
+		 __func__,
+		 ts_guc_restoring ? _("on") : _("off"),
+		 IsBinaryUpgrade ? _("yes") : _("no"));
+
+	/* When restoring deactivate extension.
+	 *
+	 * We are here relying on IsBinaryUpgrade (and ts_guc_restoring) and
+	 * should deprecate ts_guc_restoring.  If a user set this value for a
+	 * database, it will be stored in pg_db_role_settings and be included in a
+	 * dump, which will cause pg_upgrade to fail.
+	 *
+	 * See dumpDatabaseConfig in pg_dump.c. */
+	if (ts_guc_restoring || IsBinaryUpgrade)
 		return false;
 
 	if (EXTENSION_STATE_UNKNOWN == extstate || EXTENSION_STATE_TRANSITIONING == extstate)


### PR DESCRIPTION
From 63d116f208c770fe388e6d9e643d66957c8e4b25 Mon Sep 17 00:00:00 2001
From: Mats Kindahl <mats@timescale.com>
Date: Mon, 4 May 2020 12:46:01 +0200
Subject: [PATCH] Don't rely on timescaledb.restoring for upgrade

If a binary upgrade is in progress (when using `pg_upgrade`) the
per-database setting of `timescaledb.restoring` can be included in the
dump, which causes `pg_upgrade` to fail.

This commit fixes this by checking the global variable
`IsBinaryUpgrade` and not refreshing cache if we are in the middle of
doing a binary upgrade.